### PR TITLE
Remove regex lexer

### DIFF
--- a/sphinxcontrib/osexample.css
+++ b/sphinxcontrib/osexample.css
@@ -1,7 +1,7 @@
 ul.example-selector {
     display:block;
     list-style-type: none;
-    height: 15px;
+    height: 30px;
     margin: 0;
     padding: 0;
 }

--- a/sphinxcontrib/osexample.css
+++ b/sphinxcontrib/osexample.css
@@ -28,3 +28,7 @@ ul.example-selector li.selected {
 ul.example-selector li.selected:hover {
     background-color: #333;
 }
+
+.example-code.container {
+    width: auto;
+}

--- a/sphinxcontrib/osexample.py
+++ b/sphinxcontrib/osexample.py
@@ -4,91 +4,13 @@ Examplecode specs
 =================
 """
 import os
-import re
 from docutils.parsers.rst import Directive
 from docutils import nodes
 from sphinx.util.osutil import copyfile
-from pygments.lexers import get_lexer_by_name
-from pygments.lexer import RegexLexer, bygroups
-from pygments.token import Keyword, Number, Text, Comment
-from pygments.util import ClassNotFound
-from sphinx.highlighting import lexers
+
 
 CSS_FILE = 'osexample.css'
 JS_FILE = 'osexample.js'
-
-__all__ = ['UbuntuLexer', 'CentosLexer', 'FedoraLexer', 'OSXLexer']
-
-class UbuntuLexer(RegexLexer):
-    name = 'Ubuntu'
-    aliases = ['ubuntu', 'debian', 'Debian']
-    filenames = ['*.ubuntu']
-
-    tokens = {
-        'root': [
-        (r'\bapt\b', Keyword),
-        (r'\b((apt-)?get\b)', Keyword),
-        (r'\s', Text),
-        (r'-', Text),
-        (r'\S+', Keyword.Pseudo),
-        (r'[;#].*', Comment.Single),
-        ],
-    }
-
-class CentosLexer(RegexLexer):
-    name = 'Centos'
-    aliases = ['centos', 'CentOS']
-
-    tokens = {
-        'root': [
-        (r'\byum\b', Keyword),
-        (r'\b((yum)?update\b)', Keyword),
-        (r'\b((yum)?install\b)', Keyword),
-        (r'\b((yum-)?check\b)', Keyword),
-        (r'\s', Text),
-        (r'-', Text),
-        (r'\S+', Keyword.Pseudo),
-        (r'[;#].*', Comment.Single),
-        ],
-    }
-
-class FedoraLexer(RegexLexer):
-    name = 'Fedora'
-    aliases = ['fedora']
-
-    tokens = {
-        'root': [
-        (r'\bdnf\b', Keyword),
-        (r'\b((dnf)?update\b)', Keyword),
-        (r'\b((dnf)?install\b)', Keyword),
-        (r'\b((dnf-)?check\b)', Keyword),
-        (r'\s', Text),
-        (r'-', Text),
-        (r'\S+', Keyword.Pseudo),
-        (r'[;#].*', Comment.Single),
-        ],
-    }
-
-class OSXLexer(RegexLexer):
-    name = 'OSX'
-    aliases = ['osx']
-
-    tokens = {
-        'root': [
-        (r'\bbrew\b', Keyword),
-        (r'\b((brew)?install\b)', Keyword),
-        (r'\b((brew)?create\b)', Keyword),
-        (r'\b((brew)?edit\b)', Keyword),
-        (r'\b((brew)?update\b)', Keyword),
-        (r'\b((brew)?upgrade\b)', Keyword),
-        (r'\b((brew)?cleanup\b)', Keyword),
-        (r'\b((installer-)?pkg\b)', Keyword),
-        (r'\s', Text),
-        (r'-', Text),
-        (r'\S+', Keyword.Pseudo),
-        (r'[;#].*', Comment.Single),
-        ],
-    }
 
 class ExampleCodeDirective(Directive):
     """
@@ -111,7 +33,6 @@ class ExampleCodeDirective(Directive):
         self.state.nested_parse(self.content, self.content_offset, node)
         return [node]
 
-
 def add_assets(app):
     app.add_stylesheet(CSS_FILE)
     app.add_javascript(JS_FILE)
@@ -129,16 +50,16 @@ def copy_assets(app, exception):
     app.info('done')
 
 def setup(app):
-    app.add_directive('example-code',  ExampleCodeDirective)
-    app.connect('builder-inited', add_assets)
-    app.connect('build-finished', copy_assets)
     try:
-	get_lexer_by_name('ubuntu')
-	get_lexer_by_name('fedora')
-	get_lexer_by_name('centos')
-    except ClassNotFound:
-	app.add_lexer('Ubuntu', UbuntuLexer())
-	app.add_lexer('Debian', UbuntuLexer())
-	app.add_lexer('Fedora', FedoraLexer())
-	app.add_lexer('CentOS', CentosLexer())
-    app.add_lexer('OSX', OSXLexer())
+        from pygments.lexers import BashLexer
+    except ImportError:
+        pass  # not fatal if we have old (or no) Pygments
+    else:
+        # Add all lexers that should be supported here
+        app.add_lexer('Ubuntu', BashLexer())
+        app.add_lexer('Debian', BashLexer())
+        app.add_lexer('Fedora', BashLexer())
+        app.add_lexer('CentOS', BashLexer())
+        app.add_directive('osexample',  ExampleCodeDirective)
+        app.connect('builder-inited', add_assets)
+        app.connect('build-finished', copy_assets)


### PR DESCRIPTION
I found a way to get rid of the RegexLexer by using pygments BashLexer for all os examples.
